### PR TITLE
Update BOOST datasets for Uruguay and Guatemala

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This repository contains `fiscal.source-spec.yaml` files for use by [`os-data-im
 |Burkina Faso|[![Burkina Faso](https://pipelines.openspending.org/badge/collection/source-specs/os-source-specs/africa/burkina-faso)](https://pipelines.openspending.org/source-specs/os-source-specs/africa/burkina-faso)|
 |Croatia|[![Croatia](https://pipelines.openspending.org/badge/collection/source-specs/os-source-specs/europe/croatia)](https://pipelines.openspending.org/source-specs/os-source-specs/europe/croatia)|
 |Dominican Republic|[![Dominican Republic](https://pipelines.openspending.org/badge/collection/source-specs/os-source-specs/america/dominican-republic)](https://pipelines.openspending.org/source-specs/os-source-specs/america/dominican-republic)|
+|Guatemala|[![Guatemala](https://pipelines.openspending.org/badge/collection/source-specs/os-source-specs/america/guatemala)](https://pipelines.openspending.org/source-specs/os-source-specs/america/guatemala)|
 |Mexico|[![Mexico](https://pipelines.openspending.org/badge/collection/source-specs/os-source-specs/america/mexico)](https://pipelines.openspending.org/source-specs/os-source-specs/america/mexico)|
+|Uruguay|[![Uruguay](https://pipelines.openspending.org/badge/collection/source-specs/os-source-specs/america/uruguay)](https://pipelines.openspending.org/source-specs/os-source-specs/america/uruguay)|
 
 ## How can I contribute fiscal specs?
 

--- a/america/guatemala/central/fiscal.source-spec.yaml
+++ b/america/guatemala/central/fiscal.source-spec.yaml
@@ -1,0 +1,164 @@
+title: "BOOST Guatemala Central"
+private: False
+owner-id: 667df60aa07c34260eae9b55b2778712
+
+sources:
+- url: http://boost.worldbank.org/Data/boost/boostcms/files/field/country-attachments/guatemala_boost_central_2014-2015sp.xlsx
+  sheet: 2
+
+fields:
+
+
+# Fiscal year
+- header: YEAR
+  options: {}
+  columnType: date:fiscal-year
+
+
+# Administrative Classification
+- header: ADMIN1
+  options: {}
+  columnType: administrative-classification:generic:level1:code
+  title: Gobierno Central
+
+- header: ADMIN2
+  options: {}
+  columnType: administrative-classification:generic:level2:code
+  title: Entidad
+
+- header: ADMIN3
+  options: {}
+  columnType: administrative-classification:generic:level3:code
+  title: Unidad Ejecutora
+
+
+# Geo
+- header: GEO1
+  options: {}
+  columnType: geo-source:target:level1:code
+  title: Departamento
+- header: GEO2
+  options: {}
+  columnType: geo-source:target:level2:code
+  title: Municipio
+
+
+# Functional Classification
+- header: FUNC1
+  options: {}
+  columnType: functional-classification:generic:level1:code
+  title: Finalidad
+
+- header: FUNC2
+  options: {}
+  columnType: functional-classification:generic:level2:code
+  title: Función
+
+- header: FUNC3
+  options: {}
+  columnType: functional-classification:generic:level3:code
+  title: División
+
+
+# Economic Classification
+- header: ECON1
+  options: {}
+  columnType: economic-classification:generic:level1:code
+  title: "Nivel 2: Económico"
+
+- header: ECON2
+  options: {}
+  columnType: economic-classification:generic:level2:code
+  title: "Nivel 3: Económico"
+
+- header: ECON3
+  options: {}
+  columnType: economic-classification:generic:level3:code
+  title: "Nivel 4: Económico"
+
+- header: ECON4
+  options: {}
+  columnType: economic-classification:generic:level4:code
+  title: "Nivel 5: Económico"
+
+- header: ECON5
+  options: {}
+  columnType: economic-classification:generic:level5:code
+  title: Grupo
+
+- header: ECON6
+  options: {}
+  columnType: economic-classification:generic:level6:code
+  title: Sub-grupo
+
+- header: ECON7
+  options: {}
+  columnType: economic-classification:generic:level7:code
+  title: Reglón
+
+# Financial Source
+- header: SOURCE_FN1
+  options: {}
+  columnType: fin-source:generic:level1:code
+  title: Fuente agregada de financiamiento
+
+- header: SOURCE_FN2
+  options: {}
+  columnType: fin-source:generic:level2:code
+  title: Fuente de financiamiento
+
+- header: SOURCE_FN3
+  options: {}
+  columnType: fin-source:generic:level3:code
+  title: Organismo
+
+# Activity
+- header: PROGRAM1
+  options: {}
+  columnType: activity:generic:program:code
+  title: Programa
+
+- header: PROGRAM2
+  options: {}
+  columnType: activity:generic:subprogram:code
+  title: Sub-Programa
+
+- header: PROJECT1
+  options: {}
+  columnType: activity:generic:project:code
+  title: Proyecto
+
+- header: PROJECT2
+  options: {}
+  columnType: activity:generic:subproject:code
+  title: Actividad Obra
+
+
+# Measures
+- header: PHASE_ID
+  columnType: phase:id
+
+- header: PHASE
+  columnType: phase:label
+
+measures:
+  currency: GTQ
+  mapping:
+    APPROVED:
+      PHASE_ID: "0"
+      PHASE: Inicial
+    RELEASED:
+      PHASE_ID: "1"
+      PHASE: Vigente
+    COMMITTED:
+      PHASE_ID: "2"
+      PHASE: Comprometido
+    ACCRUED:
+      PHASE_ID: "3"
+      PHASE: Devengado
+    PAID:
+      PHASE_ID: "4"
+      PHASE: Pagado
+  currency-conversion: {}
+
+#postprocessing:

--- a/america/uruguay/fiscal.source-spec.yaml
+++ b/america/uruguay/fiscal.source-spec.yaml
@@ -1,0 +1,116 @@
+title: "BOOST Uruguay"
+deduplicate: true
+private: False
+owner-id: 667df60aa07c34260eae9b55b2778712
+
+sources:
+- url: http://boost.worldbank.org/Data/boost/boostcms/files/field/country-attachments/boost_uruguay_v0.9_2011-2017_spanish.xlsx
+  sheet: 2
+
+fields:
+
+
+# Fiscal year
+- header: YEAR
+  title: Año
+  options: {}
+  columnType: date:fiscal-year
+
+
+
+# Administrative Classification
+- header: ADMIN1
+  title: Inciso
+  options: {}
+  columnType: administrative-classification:generic:level1:code
+
+- header: ADMIN2
+  title: Unidad Ejecutora
+  options: {}
+  columnType: administrative-classification:generic:level2:code
+
+
+
+# Functional Classification
+- header: FUNC1
+  title: Área Programática
+  options: {}
+  columnType: functional-classification:generic:level1:code
+
+
+# Activity
+- header: PROGRAM1
+  title: Programa
+  options: {}
+  columnType: activity:generic:program:code
+
+- header: PROYECTO
+  title: Proyecto
+  options: {}
+  columnType: activity:generic:project:code
+
+
+# Financial Source
+- header: SOURCE_FIN1
+  title: Financiamiento
+  options: {}
+  columnType: fin-source:generic:level1:code
+
+- header: SOURCE_FIN2
+  title: Fuente de Financiamiento
+  options: {}
+  columnType: fin-source:generic:level2:code
+
+
+
+# Economic Classification
+- header: ECON1
+  title: Grupo
+  options: {}
+  columnType: economic-classification:generic:level1:code
+
+- header: ECON2
+  title: Subgrupo
+  options: {}
+  columnType: economic-classification:generic:level2:code
+
+- header: ECON3
+  title: Objeto del gasto
+  options: {}
+  columnType: economic-classification:generic:level3:code
+
+
+
+# Other
+- header: EXP_TYPE
+  title: Tipo de Gasto
+  options: {}
+  columnType: expenditure-type:code
+
+- header: PHASE_ID
+  title: Fase
+  options: {}
+  columnType: phase:id
+
+- header: PHASE
+  options: {}
+  columnType: phase:label
+
+
+measures:
+  currency: UYU
+  title: Monto (pesos corrientes)
+  mapping:
+    APPROVED:
+      PHASE_ID: "0"
+      PHASE: "Crédito apertura"
+    MODIFIED:
+      PHASE_ID: "1"
+      PHASE: "Crédito vigente"
+    EXECUTED:
+      PHASE_ID: "2"
+      PHASE: "Ejecutado"
+
+
+
+#postprocessing:


### PR DESCRIPTION
These were originally part of the os-data-importers source-specs (before they were moved to this os-source-specs repo). They were updated with new source links in the PR https://github.com/openspending/os-data-importers/pull/53, but not merged.

Closes openspending/os-data-importers#53. Closes openspending/openspending#1391.