### PR TITLE
Add processor to format Croatian amounts

### DIFF
--- a/europe/croatia/fiscal.source-spec.yaml
+++ b/europe/croatia/fiscal.source-spec.yaml
@@ -252,8 +252,6 @@ fields:
   options:
     currency: HRK
     phase: proposed
-    decimalChar: ","
-    groupChar: "."
   columnType: value
 
 - header: approved_value
@@ -261,8 +259,6 @@ fields:
   options:
     currency: HRK
     phase: approved
-    decimalChar: ","
-    groupChar: "."
   columnType: value
 
 - header: executed_value
@@ -270,6 +266,12 @@ fields:
   options:
     currency: HRK
     phase: executed
-    decimalChar: ","
-    groupChar: "."
   columnType: value
+
+postprocessing:
+- processor: processors/format-amounts
+  parameters:
+    columns:
+    - proposed_value
+    - approved_value
+    - executed_value

--- a/europe/croatia/processors/format-amounts.py
+++ b/europe/croatia/processors/format-amounts.py
@@ -1,0 +1,32 @@
+#encoding: utf8
+from datapackage_pipelines.wrapper import ingest, spew
+
+params, datapackage, res_iter = ingest()
+
+columns = params.get('columns')
+
+def format_number(value):
+    if not value:
+        return ''
+
+    parts = value.split(',')
+    integer = parts[0].replace('.', '')
+
+    try:
+        decimals = parts[1]
+    except IndexError:
+        decimals = '00'
+
+    new_value = '{}.{}'.format(integer, decimals)
+    return new_value
+
+
+def process_resources(_res_iter):
+    for rows in _res_iter:
+        def process_rows(_rows):
+            for row in _rows:
+                yield dict((k, v if k not in columns else format_number(v)) for (k, v)
+                           in row.items())
+        yield process_rows(rows)
+
+spew(datapackage, process_resources(res_iter))


### PR DESCRIPTION
* replace decimal separator
* replace group separator

Defining them in the source spec YAML resulted in concatenation of integral and
decimal parts into one big number. Hence the processor.